### PR TITLE
add link to Facebook page to the navigation bar

### DIFF
--- a/fsfw.css
+++ b/fsfw.css
@@ -86,6 +86,14 @@ ul#navigation > li.floated-icon {
     top: 2px;
 }
 
+ul#navigation > li.floated-icon > a {
+    /* make sure all floated-icon buttons are about the same width (the glyph
+     * on i.fa-facebook is narrower than the others) */
+    display: inline-block;
+    min-width: 1.5rem;
+    text-align: center;
+}
+
 ul#navigation > li > a > i.fa {
     font-size: 1.8rem;
 }
@@ -118,6 +126,13 @@ ul#navigation > li.twitter-blue > a:focus {
     color: white !important;
 }
 
+ul#navigation > li.facebook-blue > a:hover,
+ul#navigation > li.facebook-blue > a:active,
+ul#navigation > li.facebook-blue > a:focus {
+    background: #3B5998;
+    color: white !important;
+}
+
 ul#navigation > li.github-black > a:hover,
 ul#navigation > li.github-black > a:active,
 ul#navigation > li.github-black > a:focus {
@@ -146,19 +161,20 @@ ul#navigation > li.github-black > a:focus {
     }
 }
 
-/* On very narrow screens (e.g. iPhone 5), we condense spacings in the
+/* On narrow screens (phones in portrait mode), we get rid of expendable menu items. */
+@media (max-width: 30rem) {
+    ul#navigation > li.expendable {
+        display: none;
+    }
+}
+/* On very narrow screens (the iPhone 5, that is), we condense spacings in the
  * navigation a bit to keep it from breaking to the next line. */
-@media (max-width: 23rem) {
+@media (max-width: 19rem) {
     #navigation-area {
         padding: 0 0.3rem;
     }
     ul#navigation > li > a {
         padding: 0.3rem;
-    }
-}
-@media (max-width: 20rem) {
-    #navigation-area {
-        padding: 0;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,8 @@
             <div id="navigation-area">
                 <a href="./index.html" title="Zur Startseite"><img id="sitelogo" src="./img/sitelogo.svg" title="FSFW-Logo"></a>
                 <ul id="navigation">
-                    <li class="turquoise"><a href="./index.html">Start</a></li>
+                    <!-- This first item is expendable because index.html is also linked on the sitelogo. -->
+                    <li class="turquoise expendable"><a href="./index.html">Start</a></li>
                     <li class="violet"><a href="./themen.html">Themen</a></li>
                     <li class="green"><a href="//wiki.fsfw-dresden.de">Wiki</a></li>
                     <li class="floated-icon turquoise"><a href="mailto:kontakt@fsfw-dresden.de">
@@ -31,6 +32,10 @@
                     <li class="floated-icon github-black"><a href="https://github.com/fsfw-dresden">
                         <i class="fa fa-lg fa-github" title="Unsere GitHub-Organisation"></i>
                         <span class="hidden">Github</span>
+                    </a></li>
+                    <li class="floated-icon facebook-blue"><a href="https://facebook.com/fsfwdresden">
+                        <i class="fa fa-lg fa-facebook" title="Unsere Facebook-Seite"></i>
+                        <span class="hidden">Facebook</span>
                     </a></li>
                     <li class="floated-icon twitter-blue"><a href="https://twitter.com/fsfwdresden">
                         <i class="fa fa-lg fa-twitter" title="Unser Twitter-Account"></i>

--- a/themen.html
+++ b/themen.html
@@ -21,7 +21,8 @@
             <div id="navigation-area">
                 <a href="./index.html" title="Zur Startseite"><img id="sitelogo" src="./img/sitelogo.svg" title="FSFW-Logo"></a>
                 <ul id="navigation">
-                    <li class="turquoise"><a href="./index.html">Start</a></li>
+                    <!-- This first item is expendable because index.html is also linked on the sitelogo. -->
+                    <li class="turquoise expendable"><a href="./index.html">Start</a></li>
                     <li class="violet"><a href="./themen.html">Themen</a></li>
                     <li class="green"><a href="//wiki.fsfw-dresden.de">Wiki</a></li>
                     <li class="floated-icon turquoise"><a href="mailto:kontakt@fsfw-dresden.de">
@@ -31,6 +32,10 @@
                     <li class="floated-icon github-black"><a href="https://github.com/fsfw-dresden">
                         <i class="fa fa-lg fa-github" title="Unsere GitHub-Organisation"></i>
                         <span class="hidden">Github</span>
+                    </a></li>
+                    <li class="floated-icon facebook-blue"><a href="https://facebook.com/fsfwdresden">
+                        <i class="fa fa-lg fa-facebook" title="Unsere Facebook-Seite"></i>
+                        <span class="hidden">Facebook</span>
                     </a></li>
                     <li class="floated-icon twitter-blue"><a href="https://twitter.com/fsfwdresden">
                         <i class="fa fa-lg fa-twitter" title="Unser Twitter-Account"></i>


### PR DESCRIPTION
I optimized the spacing a bit in the process, and added a media query to get rid of the "Start" link on narrow screens since it's expendable. Tested on Firefox (Desktop), Firefox for Android on Nexus 4, and Safari on iPhone 5.

Please merge this only after making sure that the Facebook page is ready for the public.
