### PR TITLE
LPD von der Homepage nehmen

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,6 @@
         <hr>
         <section id="news">
             <h2>Aktuelles</h2>
-            <section id="lpd">
-              <h3>Linux-Presentation-Day mit Install-Party</h3>
-              <p>Am Samstag den 30. April ist der Linux-Presentation-Day 2016. Die FSFW Dresden bietet an diesem Tag ein Programm aus Informationsvortrag und dem Angebot, bei der Installation und Einrichtung von Linux behilflich zu sein, an. Weitere <a href="https://fsfw-dresden.de/lpd">Infos in unserem Wiki</a>.</p>
-            </section>
             <section id="latex-sprechstunde">
                 <h3>LaTeX und LibreOffice Sprechstunde</h3>
                 <p>Wir bieten seit dem Wintersemester 15/16 regelmäßig eine


### PR DESCRIPTION
entfernen des Abschnittes über den letzten LPD

wie von CK in Mail vom 17 Jun 16 10:14 gefordert; 
nächster LPD absehbar während den [Datenspuren 2016](https://datenspuren.de/2016/)
