### PR TITLE
1-farbiges Logo aus Anlass "Aktion USB-Stick"

### DIFF
--- a/docroot/img/logo-1farbig.svg
+++ b/docroot/img/logo-1farbig.svg
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="50.799999mm"
+   height="50.799999mm"
+   viewBox="0 0 180 180"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="fsfw-1farbig.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1022"
+     id="namedview38"
+     showgrid="false"
+     inkscape:zoom="3.7083823"
+     inkscape:cx="223.56263"
+     inkscape:cy="66.594197"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4388" />
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-238.07693,-827.21405)"
+     id="g4388">
+    <g
+       id="g4220">
+      <g
+         id="g4192">
+        <g
+           id="g5892-2-6-5"
+           transform="translate(33.343613,308.75232)">
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 214.35635,593.74488 c 0,0 62.02172,1.15107 73.74858,16.76021 1.23222,1.70616 6.4913,1.96986 6.4913,1.96986"
+             id="path5894-4-0-6" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path5896-36-6-6"
+             d="m 291.20314,611.54774 c -0.71771,-20.57437 -75.17213,-24.26226 -75.17213,-24.26226"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 293.86867,611.92689 c -0.23924,-27.03377 -75.92376,-30.62233 -75.92376,-30.62233"
+             id="path5898-2-4-1" />
+        </g>
+        <use
+           height="100%"
+           width="100%"
+           transform="matrix(-1,0,0,1,656.15388,2.8560021e-7)"
+           id="use5992-1-4-0"
+           xlink:href="#g5892-2-6-5"
+           y="0"
+           x="0" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1,3;stroke-opacity:1;stroke-dashoffset:0"
+           id="rect5118-6-5-0-8-4"
+           width="5"
+           height="5"
+           x="325.60172"
+           y="906.03302" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:1;stroke-dasharray:2,4;stroke-opacity:1;stroke-dashoffset:0"
+           id="rect5118-6-0-6-9"
+           width="7.5"
+           height="7.5"
+           x="331.34241"
+           y="896.16119" />
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-5-6-5-7"
+           width="5"
+           height="5"
+           x="320.94125"
+           y="897.87726" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1,3;stroke-opacity:1;stroke-dashoffset:0"
+           id="rect5118-6-1-2-6"
+           width="7.5"
+           height="7.5"
+           x="306.17584"
+           y="888.47137" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:1;stroke-dasharray:2,4;stroke-opacity:1;stroke-dashoffset:0"
+           id="rect5118-0-4-4"
+           width="10"
+           height="10"
+           x="317.74219"
+           y="883.02698" />
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-5-8-3-1"
+           width="5"
+           height="5"
+           x="330.96127"
+           y="887.85718" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-5-4-1-8"
+           width="5"
+           height="5"
+           x="343.31152"
+           y="892.75067" />
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-9-8-4"
+           width="7.5"
+           height="7.5"
+           x="339.0322"
+           y="881.94672" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:1;stroke-dasharray:2,4;stroke-opacity:1;stroke-dashoffset:0"
+           id="rect5118-6-5-2-1-2"
+           width="5"
+           height="5"
+           x="353.09854"
+           y="889.72137" />
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-04-7-7"
+           width="10"
+           height="10"
+           x="262.2825"
+           y="872.54083" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1,3;stroke-opacity:1;stroke-dashoffset:0"
+           id="rect5118-6-5-66-8-2"
+           width="5"
+           height="5"
+           x="278.29788"
+           y="882.73065" />
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-5-9-7-1"
+           width="5"
+           height="5"
+           x="298.10489"
+           y="879.23529" />
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-3-5-4"
+           width="7.5"
+           height="7.5"
+           x="287.30093"
+           y="866.10107" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:1;stroke-dasharray:2,4;stroke-opacity:1;stroke-dashoffset:0"
+           id="rect5118-6-55-9-1"
+           width="7.5"
+           height="7.5"
+           x="310.6033"
+           y="865.86804" />
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-5-86-5-6"
+           width="5"
+           height="5"
+           x="328.39798"
+           y="870.6134" />
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-8-1-5"
+           width="10"
+           height="10"
+           x="366.44412"
+           y="870.6767" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1,3;stroke-opacity:1;stroke-dashoffset:0"
+           id="rect5118-6-5-1-5-8"
+           width="5"
+           height="5"
+           x="343.31152"
+           y="873.17664" />
+        <rect
+           style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-5-84-7-5"
+           width="5"
+           height="5"
+           x="377.56601"
+           y="884.27661" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-5-62-2-9"
+           width="5"
+           height="5"
+           x="388.75119"
+           y="874.57477" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect5118-6-8-6-4"
+           width="7.5"
+           height="7.5"
+           x="307.10794"
+           y="878.45135" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:1;stroke-dasharray:2,4;stroke-opacity:1;stroke-dashoffset:0"
+           id="rect5118-6-80-0-7"
+           width="7.5"
+           height="7.5"
+           x="354.64481"
+           y="870.29547" />
+      </g>
+      <g
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:89.99999762%;font-family:Titillium;-inkscape-font-specification:'Titillium Semi-Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="text5950-5-5-8">
+        <path
+           d="m 255.90725,967.90002 6.66,0 0,-15.6 15.66,0 0,-5.82 -15.66,0 0,-13.86 18.84,0 0,-5.82 -25.5,0 0,41.1 z"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:Titillium;-inkscape-font-specification:'Titillium Semi-Bold'"
+           id="path3561" />
+        <path
+           d="m 311.91069,927.52002 c 0,0 -7.8,-1.44 -13.02,-1.44 -8.22,0 -13.68,3.42 -13.68,11.7 0,7.14 3.84,9.84 12.72,12.12 6.3,1.5 8.16,2.7 8.16,6.18 0,4.32 -2.34,6.6 -7.44,6.6 -4.26,0 -12.36,-1.08 -12.36,-1.08 l -0.66,5.34 c 0,0 8.1,1.62 13.44,1.62 8.1,0 13.74,-3.9 13.74,-12.9 0,-7.02 -3.12,-9.3 -11.76,-11.7 -7.02,-1.92 -9.18,-2.82 -9.18,-6.66 0,-3.54 2.58,-5.34 7.62,-5.34 3.48,0 11.88,0.96 11.88,0.96 l 0.54,-5.4 z"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:Titillium;-inkscape-font-specification:'Titillium Semi-Bold'"
+           id="path3563" />
+        <path
+           d="m 320.00881,967.90002 6.66,0 0,-15.6 15.66,0 0,-5.82 -15.66,0 0,-13.86 18.84,0 0,-5.82 -25.5,0 0,41.1 z"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:Titillium;-inkscape-font-specification:'Titillium Semi-Bold'"
+           id="path3565" />
+        <path
+           d="m 348.46663,926.80002 8.04,41.1 10.8,0 7.02,-32.94 7.08,32.94 10.74,0 8.1,-41.1 -7.02,0 -5.88,35.34 -1.32,0 -7.8,-35.22 -7.8,0 -7.8,35.22 -1.26,0 -5.88,-35.34 -7.02,0 z"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:Titillium;-inkscape-font-specification:'Titillium Semi-Bold'"
+           id="path3567" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Hier ein Vorschlag; mehr Alternativen willkommen.

Für den Stick ist ein einfarbiger Druck die kostengünstigste Option.
Für den Fall, dass das FSFW Logo drauf kommt, sollten wir das vorbeireiten.
